### PR TITLE
Add Broadcom 5754 Support

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -39,6 +39,7 @@
 				<string>pci14e4,1672</string>
 				<string>pci14e4,167b</string>
 				<string>pci14e4,1673</string>
+				<string>pci14e4,1681</string>
 				<string>pci14e4,1691</string>
 				<string>pci14e4,169b</string>
 				<string>pci14e4,1693</string>


### PR DESCRIPTION
With adding this value the Broadcom 5754 Gigabit Controller will work (tested on MacOS Sierra 10.12)